### PR TITLE
Remove dates from the urls in the posts

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -75,3 +75,5 @@ exclude:
    - vendor/cache/
    - vendor/gems/
    - vendor/ruby/
+
+permalink: /:categories/:title.html


### PR DESCRIPTION
Fix date links
before :  https://www.epicbounties.com/en/2021/05/20/english-sample.html
after : https://www.epicbounties.com/en/english-sample.html


